### PR TITLE
[Epic 2] Frontend auth: JWT store, Axios interceptor, login page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "crisislens-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.13.5",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.575.0",
         "react": "^18.2.0",
@@ -1385,6 +1386,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
@@ -1420,6 +1427,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1493,6 +1511,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/camelcase-css": {
@@ -1571,6 +1602,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -1761,6 +1804,15 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1775,12 +1827,71 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-toolkit": {
       "version": "1.44.0",
@@ -1900,6 +2011,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -1933,7 +2080,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1949,6 +2095,43 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1962,11 +2145,49 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2155,6 +2376,15 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2177,6 +2407,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/ms": {
@@ -2462,6 +2713,12 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.13.5",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.575.0",
     "react": "^18.2.0",

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,43 @@
+/**
+ * api/auth.js
+ *
+ * Thin wrappers around the backend auth endpoints.
+ * All calls go through `client` so they benefit from the JWT interceptors.
+ *
+ * Endpoint notes (backend uses simplejwt with USERNAME_FIELD = "email"):
+ *   POST /api/auth/login/   { email, password }        → { access, refresh }
+ *   POST /api/auth/refresh/ { refresh }                → { access, refresh }
+ *   POST /api/auth/logout/  { refresh }                → { detail }
+ *   GET  /api/auth/me/                                  → UserSerializer
+ */
+import client from './client';
+
+/**
+ * Exchange email + password for a token pair.
+ * The simplejwt login serializer respects USERNAME_FIELD so we send "email"
+ * as the key directly — no mapping needed.
+ */
+export const loginRequest = (email, password) =>
+    client.post('/api/auth/login/', { email, password });
+
+/**
+ * Blacklist the current refresh token on the backend.
+ * Call before calling useAuthStore.logout() so the token cannot be reused.
+ */
+export const logoutRequest = (refresh) =>
+    client.post('/api/auth/logout/', { refresh });
+
+/**
+ * Fetch the authenticated user's profile.
+ * The Bearer token is attached by the request interceptor.
+ */
+export const getMeRequest = () =>
+    client.get('/api/auth/me/');
+
+/**
+ * Explicitly refresh the access token.
+ * Normally handled transparently by the 401 interceptor in client.js,
+ * but exported here so AuthProvider can call it on cold start.
+ */
+export const refreshRequest = (refreshToken) =>
+    client.post('/api/auth/refresh/', { refresh: refreshToken });

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,77 @@
+/**
+ * api/client.js
+ *
+ * Pre-configured Axios instance with two interceptors:
+ *
+ * REQUEST  → attaches the in-memory Bearer access token to every call.
+ * RESPONSE → on 401, attempts one silent refresh using the stored refresh
+ *             token; if that also fails (or no refresh token exists) it
+ *             calls logout() and lets the AuthProvider redirect to /login.
+ *
+ * We read the store via `useAuthStore.getState()` instead of the React hook
+ * so this module works outside of the React component tree.
+ */
+import axios from 'axios';
+import { useAuthStore } from '../store/authStore';
+
+const client = axios.create({
+    baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8000',
+    headers: { 'Content-Type': 'application/json' },
+    timeout: 15_000,
+});
+
+/* ── REQUEST: attach Bearer token ─────────────────────────────────────── */
+client.interceptors.request.use(
+    (config) => {
+        const token = useAuthStore.getState().accessToken;
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`;
+        }
+        return config;
+    },
+    (error) => Promise.reject(error),
+);
+
+/* ── RESPONSE: silent token refresh on 401 ────────────────────────────── */
+client.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const original = error.config;
+
+        // Only attempt silent refresh on 401 and only once per request.
+        if (error.response?.status === 401 && !original._retry) {
+            original._retry = true;
+
+            const refresh = localStorage.getItem('cl-refresh');
+            if (refresh) {
+                try {
+                    // Use a bare axios call (not `client`) to avoid the interceptor loop.
+                    const { data } = await axios.post(
+                        `${client.defaults.baseURL}/api/auth/refresh/`,
+                        { refresh },
+                        { headers: { 'Content-Type': 'application/json' } },
+                    );
+
+                    // simplejwt returns both a new access and (with ROTATE_REFRESH_TOKENS) a new refresh.
+                    useAuthStore.getState().setAccessToken(data.access);
+                    if (data.refresh) {
+                        localStorage.setItem('cl-refresh', data.refresh);
+                    }
+
+                    // Retry the original request with the new access token.
+                    original.headers.Authorization = `Bearer ${data.access}`;
+                    return client(original);
+                } catch {
+                    // Refresh also failed — log the user out completely.
+                    useAuthStore.getState().logout();
+                }
+            } else {
+                useAuthStore.getState().logout();
+            }
+        }
+
+        return Promise.reject(error);
+    },
+);
+
+export default client;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import AppRouter from './router/AppRouter.jsx';
+import AuthProvider from './providers/AuthProvider.jsx';
 import './index.css';
 import 'leaflet/dist/leaflet.css';
 
-// Replaced pathname-sniffing and provisional elements with robust React Router (Issue #48)
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <AppRouter />
+    <AuthProvider>
+      <AppRouter />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,33 +1,358 @@
-import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useAuthStore } from '../store/useAuthStore';
-import { Button } from '../components/ui';
+/**
+ * pages/LoginPage.jsx — Issue #10
+ *
+ * Production split-screen login page.
+ *
+ * Layout
+ * ──────
+ *  Left (40%, hidden on mobile)  — dark navy brand panel
+ *    • CrisisLens logo + wordmark
+ *    • Tagline
+ *    • 3 stat pills
+ *    • Footer attribution
+ *
+ *  Right (100% / 60% desktop)    — white/light auth panel
+ *    • "Sign in" heading
+ *    • Email + password inputs with inline validation
+ *    • Inline 401 error banner
+ *    • Sign In button (loading state while request is in-flight)
+ *    • "Quick Access" divider + 5 demo role buttons
+ *
+ * Auth flow
+ * ─────────
+ *  1. POST /api/auth/login/ { email, password }
+ *  2. Store refresh token in localStorage("cl-refresh")
+ *  3. Call useAuthStore.login(access, user) — access stays in memory
+ *  4. Navigate to the originally requested URL (or /dashboard)
+ */
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Activity, AlertTriangle, Users, MapPin, Eye, EyeOff } from 'lucide-react';
+import { useAuthStore } from '../store/authStore';
+import { loginRequest, getMeRequest } from '../api/auth';
+import Spinner from '../components/ui/Spinner';
 
+/* ── Demo accounts (Quick Access) ──────────────────────────────────────── */
+const DEMO_ACCOUNTS = [
+    { label: 'National Ops',              email: 'ops@crisislens.go.ke',       password: 'Demo1234!' },
+    { label: 'County Officer (Kisumu)',   email: 'kisumu@crisislens.go.ke',    password: 'Demo1234!' },
+    { label: 'County Officer (Siaya)',    email: 'siaya@crisislens.go.ke',     password: 'Demo1234!' },
+    { label: 'Responder',                 email: 'responder@crisislens.go.ke', password: 'Demo1234!' },
+    { label: 'Analyst',                   email: 'analyst@crisislens.go.ke',   password: 'Demo1234!' },
+];
+
+/* ── Stat pill (left panel) ─────────────────────────────────────────────── */
+function StatPill({ icon: Icon, value, label }) {
+    return (
+        <div className="flex items-center gap-2.5 bg-white/5 border border-white/10 rounded px-3 py-2">
+            <Icon size={14} className="text-flood-400 shrink-0" />
+            <span className="text-white text-xs font-semibold font-mono">{value}</span>
+            <span className="text-slate-400 text-xs">{label}</span>
+        </div>
+    );
+}
+
+/* ── Input field ────────────────────────────────────────────────────────── */
+function Field({ id, label, type = 'text', value, onChange, error, autoComplete, rightElement }) {
+    return (
+        <div>
+            <label htmlFor={id} className="block text-xs font-medium text-slate-600 mb-1">
+                {label}
+            </label>
+            <div className="relative">
+                <input
+                    id={id}
+                    type={type}
+                    value={value}
+                    onChange={onChange}
+                    autoComplete={autoComplete}
+                    className={[
+                        'w-full px-3 py-2 text-sm bg-white border rounded',
+                        'text-slate-900 placeholder-slate-400',
+                        'focus:outline-none focus:ring-2 focus:ring-flood-500 focus:border-transparent',
+                        'transition-colors duration-150',
+                        error
+                            ? 'border-red-400 focus:ring-red-400'
+                            : 'border-slate-300 hover:border-slate-400',
+                        rightElement ? 'pr-10' : '',
+                    ].join(' ')}
+                    placeholder={type === 'email' ? 'you@example.com' : '••••••••'}
+                />
+                {rightElement && (
+                    <div className="absolute inset-y-0 right-0 flex items-center pr-3">
+                        {rightElement}
+                    </div>
+                )}
+            </div>
+            {error && (
+                <p className="mt-1 text-xs text-red-500 flex items-center gap-1">
+                    <AlertTriangle size={11} />
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════ */
 export default function LoginPage() {
-    const navigate = useNavigate();
-    const location = useLocation();
-    const login = useAuthStore((state) => state.login);
+    const navigate   = useNavigate();
+    const location   = useLocation();
+    const { login }  = useAuthStore();
 
-    // Where they tried to go before being redirected to login
     const from = location.state?.from?.pathname || '/dashboard';
 
-    const handleLogin = (role) => {
-        login(role);
-        navigate(from, { replace: true });
-    };
+    /* Form state */
+    const [email,       setEmail]       = useState('');
+    const [password,    setPassword]    = useState('');
+    const [showPwd,     setShowPwd]     = useState(false);
+    const [errors,      setErrors]      = useState({});
+    const [apiError,    setApiError]    = useState('');
+    const [loading,     setLoading]     = useState(false);
+    const [demoLoading, setDemoLoading] = useState(null); // index of active demo btn
 
+    /* ── Validation ────────────────────────────────────────────────────── */
+    function validate(em, pw) {
+        const e = {};
+        if (!em.trim())                      e.email    = 'Email is required';
+        else if (!/\S+@\S+\.\S+/.test(em))  e.email    = 'Enter a valid email address';
+        if (!pw)                             e.password = 'Password is required';
+        return e;
+    }
+
+    /* ── Core sign-in logic ─────────────────────────────────────────────── */
+    async function signIn(em, pw, demoIdx = null) {
+        setApiError('');
+        setErrors({});
+
+        const validationErrors = validate(em, pw);
+        if (Object.keys(validationErrors).length) {
+            setErrors(validationErrors);
+            return;
+        }
+
+        if (demoIdx !== null) setDemoLoading(demoIdx);
+        else setLoading(true);
+
+        try {
+            const { data: tokens } = await loginRequest(em, pw);
+
+            // Persist the refresh token so AuthProvider can silently rehydrate on
+            // the next hard refresh. Access token stays in memory via the store.
+            localStorage.setItem('cl-refresh', tokens.refresh);
+
+            // Fetch full user profile using the new access token.
+            // The request interceptor in client.js attaches the Bearer header
+            // as soon as we call setAccessToken, but here we're mid-flow so we
+            // pass the token manually via getMeRequest (client picks it up via store
+            // after login is called — but we haven't called login yet).
+            // Simplest approach: call getMeRequest after a temporary store update.
+            useAuthStore.getState().setAccessToken(tokens.access);
+            const { data: user } = await getMeRequest();
+
+            // Full hydration — replaces the temporary setAccessToken call above.
+            login(tokens.access, user);
+
+            navigate(from, { replace: true });
+        } catch (err) {
+            // Reset any temporary token we set during the flow.
+            useAuthStore.getState().setAccessToken(null);
+
+            const status = err.response?.status;
+            if (status === 401) {
+                setApiError('Invalid email or password. Please try again.');
+            } else if (status >= 500) {
+                setApiError('Server error — please try again in a moment.');
+            } else {
+                setApiError('Unable to connect. Check your network and try again.');
+            }
+        } finally {
+            setLoading(false);
+            setDemoLoading(null);
+        }
+    }
+
+    /* ── Form submit ────────────────────────────────────────────────────── */
+    function handleSubmit(e) {
+        e.preventDefault();
+        signIn(email, password);
+    }
+
+    /* ── Demo button ────────────────────────────────────────────────────── */
+    function handleDemo(account, idx) {
+        setEmail(account.email);
+        setPassword(account.password);
+        signIn(account.email, account.password, idx);
+    }
+
+    const busy = loading || demoLoading !== null;
+
+    /* ══════════════════════════════════════════════════════════════════════ */
     return (
-        <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-surface p-4">
-            <div className="max-w-md w-full bg-white dark:bg-surface-raised p-8 rounded-2xl shadow-lg border border-gray-100 dark:border-surface-border">
-                <h2 className="text-2xl font-bold mb-6 text-center text-gray-900 dark:text-white">CrisisLens Login</h2>
-                <div className="space-y-3">
-                    <Button className="w-full justify-center" onClick={() => handleLogin('national_ops')}>Login as National Ops</Button>
-                    <Button className="w-full justify-center" variant="outline" onClick={() => handleLogin('county_officer')}>Login as County Officer</Button>
-                    <Button className="w-full justify-center" variant="outline" onClick={() => handleLogin('responder')}>Login as Responder</Button>
-                    <Button className="w-full justify-center" variant="outline" onClick={() => handleLogin('analyst')}>Login as Analyst</Button>
-                    <Button className="w-full justify-center" variant="outline" onClick={() => handleLogin('super_admin')}>Login as Super Admin</Button>
+        <div className="min-h-screen flex">
+
+            {/* ══ LEFT — Brand panel (hidden on mobile) ══════════════════════════ */}
+            <aside className="hidden lg:flex lg:w-2/5 flex-col justify-between bg-surface p-10 relative overflow-hidden">
+
+                {/* Decorative background blobs */}
+                <div className="absolute -top-24 -left-24 w-80 h-80 rounded-full bg-flood-600/10 blur-3xl pointer-events-none" />
+                <div className="absolute -bottom-24 -right-16 w-96 h-96 rounded-full bg-flood-800/20 blur-3xl pointer-events-none" />
+
+                {/* Logo + wordmark */}
+                <div className="relative z-10">
+                    <div className="flex items-center gap-3 mb-8">
+                        <div className="w-9 h-9 rounded bg-flood-600 flex items-center justify-center shrink-0">
+                            <Activity size={18} className="text-white" />
+                        </div>
+                        <span className="text-white font-semibold text-lg tracking-tight font-mono">
+                            CrisisLens
+                        </span>
+                    </div>
+
+                    <h1 className="text-2xl font-bold text-white leading-snug mb-3">
+                        National Predictive Risk<br />
+                        &amp; Early Warning System
+                    </h1>
+                    <p className="text-slate-400 text-sm leading-relaxed max-w-xs">
+                        Real-time flood risk intelligence for Kenya's Lake Victoria Basin —
+                        enabling faster, evidence-based emergency response.
+                    </p>
                 </div>
-            </div>
+
+                {/* Stat pills */}
+                <div className="relative z-10 space-y-2.5">
+                    <StatPill icon={MapPin} value="3"     label="Counties monitored" />
+                    <StatPill icon={MapPin} value="21"    label="Sub-counties covered" />
+                    <StatPill icon={Users}  value="3.28M" label="People in coverage area" />
+                </div>
+
+                {/* Footer */}
+                <div className="relative z-10">
+                    <div className="w-8 h-px bg-flood-600 mb-3" />
+                    <p className="text-slate-500 text-xs">Lake Victoria Basin · Kenya</p>
+                    <p className="text-slate-600 text-xs mt-0.5">Operational intelligence platform</p>
+                </div>
+            </aside>
+
+            {/* ══ RIGHT — Auth panel ═════════════════════════════════════════════ */}
+            <main className="flex-1 flex flex-col justify-center items-center bg-slate-50 px-6 py-12">
+                <div className="w-full max-w-sm">
+
+                    {/* Mobile-only logo */}
+                    <div className="flex items-center gap-2 mb-8 lg:hidden">
+                        <div className="w-8 h-8 rounded bg-flood-600 flex items-center justify-center">
+                            <Activity size={16} className="text-white" />
+                        </div>
+                        <span className="font-semibold text-slate-900 font-mono">CrisisLens</span>
+                    </div>
+
+                    {/* Page heading */}
+                    <div className="mb-6">
+                        <h2 className="text-xl font-semibold text-slate-900">Sign in to CrisisLens</h2>
+                        <p className="text-slate-500 text-sm mt-0.5">Enter your credentials to continue</p>
+                    </div>
+
+                    {/* API error banner */}
+                    {apiError && (
+                        <div className="mb-4 flex items-start gap-2.5 bg-red-50 border border-red-200 text-red-700 text-sm rounded px-3 py-2.5">
+                            <AlertTriangle size={15} className="mt-0.5 shrink-0" />
+                            <span>{apiError}</span>
+                        </div>
+                    )}
+
+                    {/* Credentials form */}
+                    <form onSubmit={handleSubmit} noValidate className="space-y-4">
+                        <Field
+                            id="email"
+                            label="Email address"
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            error={errors.email}
+                            autoComplete="email"
+                        />
+
+                        <Field
+                            id="password"
+                            label="Password"
+                            type={showPwd ? 'text' : 'password'}
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            error={errors.password}
+                            autoComplete="current-password"
+                            rightElement={
+                                <button
+                                    type="button"
+                                    onClick={() => setShowPwd(!showPwd)}
+                                    className="text-slate-400 hover:text-slate-600 transition-colors"
+                                    aria-label={showPwd ? 'Hide password' : 'Show password'}
+                                >
+                                    {showPwd ? <EyeOff size={15} /> : <Eye size={15} />}
+                                </button>
+                            }
+                        />
+
+                        <button
+                            type="submit"
+                            disabled={busy}
+                            className={[
+                                'w-full flex items-center justify-center gap-2',
+                                'bg-flood-600 hover:bg-flood-700 active:bg-flood-800',
+                                'text-white text-sm font-medium',
+                                'px-4 py-2.5 rounded',
+                                'focus:outline-none focus:ring-2 focus:ring-flood-500 focus:ring-offset-2',
+                                'transition-colors duration-150',
+                                'disabled:opacity-60 disabled:cursor-not-allowed',
+                            ].join(' ')}
+                        >
+                            {loading && <Spinner size="sm" />}
+                            {loading ? 'Signing in…' : 'Sign In'}
+                        </button>
+                    </form>
+
+                    {/* Demo accounts divider */}
+                    <div className="my-6 flex items-center gap-3">
+                        <div className="flex-1 h-px bg-slate-200" />
+                        <span className="text-xs text-slate-400 shrink-0">Quick Access</span>
+                        <div className="flex-1 h-px bg-slate-200" />
+                    </div>
+
+                    {/* Demo role buttons */}
+                    <div className="space-y-1.5">
+                        {DEMO_ACCOUNTS.map((account, idx) => (
+                            <button
+                                key={account.email}
+                                type="button"
+                                onClick={() => handleDemo(account, idx)}
+                                disabled={busy}
+                                className={[
+                                    'w-full flex items-center justify-between',
+                                    'bg-white hover:bg-slate-50 active:bg-slate-100',
+                                    'border border-slate-200 hover:border-slate-300',
+                                    'text-slate-700 text-xs',
+                                    'px-3 py-2 rounded',
+                                    'focus:outline-none focus:ring-2 focus:ring-flood-500 focus:ring-offset-1',
+                                    'transition-colors duration-100',
+                                    'disabled:opacity-50 disabled:cursor-not-allowed',
+                                ].join(' ')}
+                            >
+                                <span className="font-medium">{account.label}</span>
+                                <span className="flex items-center gap-1.5 text-slate-400">
+                                    {demoLoading === idx
+                                        ? <Spinner size="sm" />
+                                        : <span className="font-mono text-[10px]">{account.email.split('@')[0]}</span>
+                                    }
+                                </span>
+                            </button>
+                        ))}
+                    </div>
+
+                    {/* Demo password note */}
+                    <p className="mt-5 text-center text-xs text-slate-400">
+                        Demo password: <span className="font-mono text-slate-500">Demo1234!</span>
+                    </p>
+                </div>
+            </main>
         </div>
     );
 }

--- a/frontend/src/providers/AuthProvider.jsx
+++ b/frontend/src/providers/AuthProvider.jsx
@@ -1,0 +1,79 @@
+/**
+ * providers/AuthProvider.jsx
+ *
+ * Runs once on cold start (hard refresh, new tab, Cmd+R).
+ *
+ * Flow:
+ *  1. Check localStorage for "cl-refresh".
+ *  2. If found, POST /api/auth/refresh/ to get a new access token.
+ *  3. Store the new refresh token (simplejwt rotates it).
+ *  4. Call GET /api/auth/me/ to load the full user profile.
+ *  5. Hydrate the authStore — user is logged in without seeing the login page.
+ *
+ * While booting, render a minimal splash screen to prevent a flash to /login.
+ * Any failure clears the stored refresh token and shows children unauthenticated.
+ */
+import { useEffect, useState } from 'react';
+import { useAuthStore } from '../store/authStore';
+import { refreshRequest, getMeRequest } from '../api/auth';
+
+export default function AuthProvider({ children }) {
+    const [booting, setBooting] = useState(true);
+    const { login } = useAuthStore();
+
+    useEffect(() => {
+        const stored = localStorage.getItem('cl-refresh');
+
+        if (!stored) {
+            setBooting(false);
+            return;
+        }
+
+        refreshRequest(stored)
+            .then(({ data }) => {
+                // Persist the rotated refresh token before fetching the user.
+                if (data.refresh) {
+                    localStorage.setItem('cl-refresh', data.refresh);
+                }
+                // Return both the new access token and the /me/ call in parallel.
+                return Promise.all([data.access, getMeRequest()]);
+            })
+            .then(([access, meRes]) => {
+                login(access, meRes.data);
+            })
+            .catch(() => {
+                // Refresh token expired or blacklisted — clear it and start fresh.
+                localStorage.removeItem('cl-refresh');
+            })
+            .finally(() => {
+                setBooting(false);
+            });
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    if (booting) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-surface">
+                <div className="flex flex-col items-center gap-3">
+                    <svg
+                        className="w-8 h-8 text-flood-600 animate-pulse"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M13 10V3L4 14h7v7l9-11h-7z"
+                        />
+                    </svg>
+                    <span className="text-slate-400 text-xs font-mono tracking-widest uppercase">
+                        Initialising…
+                    </span>
+                </div>
+            </div>
+        );
+    }
+
+    return children;
+}

--- a/frontend/src/router/DashboardRouter.jsx
+++ b/frontend/src/router/DashboardRouter.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { useAuthStore } from '../store/useAuthStore';
+import { useAuthStore } from '../store/authStore';
 
 /**
  * A gateway route for /dashboard that reads the user's role and redirects

--- a/frontend/src/router/PrivateRoute.jsx
+++ b/frontend/src/router/PrivateRoute.jsx
@@ -1,26 +1,29 @@
+/**
+ * router/PrivateRoute.jsx
+ *
+ * Guards a route by:
+ *  1. Checking `isAuthenticated` from the real authStore.
+ *     — Unauthenticated → redirect to /login, saving the attempted URL so we
+ *       can send them back after a successful sign-in.
+ *  2. Optionally checking `allowedRoles`.
+ *     — Wrong role → redirect to /unauthorized.
+ *
+ * AuthProvider has already handled the silent rehydration on cold start,
+ * so by the time this component renders `isAuthenticated` is authoritative.
+ */
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useAuthStore } from '../store/useAuthStore';
+import { useAuthStore } from '../store/authStore';
 
-/**
- * A wrapper for guarded routes. 
- * Checks if the user is authenticated; if not, redirects to login with the attempted URL in state.
- * If authorized roles are provided, checks against the user's role; redirects to unauthorized if it doesn't match.
- */
 export default function PrivateRoute({ children, allowedRoles }) {
     const { isAuthenticated, user } = useAuthStore();
     const location = useLocation();
 
     if (!isAuthenticated) {
-        // Redirect them to the /login page, but save the current location they were
-        // trying to go to when they were redirected. This allows us to send them
-        // along to that page after they login, which is a nicer user experience
-        // than dropping them off on the home page.
         return <Navigate to="/login" state={{ from: location }} replace />;
     }
 
     if (allowedRoles && (!user || !allowedRoles.includes(user.role))) {
-        // User is logged in but does not have the required role
         return <Navigate to="/unauthorized" replace />;
     }
 

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -1,0 +1,45 @@
+/**
+ * store/authStore.js
+ *
+ * Single source of truth for authentication state.
+ *
+ * Security model:
+ *  - Access token lives in MEMORY only (this store) — never localStorage / cookies
+ *    so it cannot be stolen via XSS reading storage.
+ *  - Refresh token is persisted to localStorage("cl-refresh") ONLY so the user
+ *    survives hard refreshes without re-logging-in. On logout it is removed.
+ *  - AuthProvider silently exchanges the stored refresh token for a fresh access
+ *    token on every cold start (hard refresh / new tab).
+ */
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+    /** Full user profile returned by /api/auth/me/ */
+    user: null,
+
+    /** Short-lived JWT access token — in memory only, never persisted */
+    accessToken: null,
+
+    /** Derived flag — true when we have a live access token */
+    isAuthenticated: false,
+
+    /**
+     * Called after a successful login or silent token rehydration.
+     * Stores the access token in memory; the refresh token is written
+     * to localStorage by the caller (AuthProvider / LoginPage).
+     */
+    login: (accessToken, user) =>
+        set({ accessToken, user, isAuthenticated: true }),
+
+    /**
+     * Wipes in-memory token + user and removes the persisted refresh token.
+     * Always call this on explicit logout OR when refresh fails.
+     */
+    logout: () => {
+        localStorage.removeItem('cl-refresh');
+        set({ accessToken: null, user: null, isAuthenticated: false });
+    },
+
+    /** Called by the Axios 401 interceptor after a silent token refresh. */
+    setAccessToken: (accessToken) => set({ accessToken }),
+}));


### PR DESCRIPTION
## Summary

- **#11** — Real Zustand `authStore` replacing the hardcoded mock; Axios `client.js` with Bearer token request interceptor + silent 401 refresh response interceptor; `AuthProvider` for cold-start token rehydration; `api/auth.js` typed endpoint wrappers
- **#10** — Production IBM-style split-screen `LoginPage` with real JWT auth flow; replaces the dev role-selector button page

## Changes

### Issue #11 — Auth store + Axios client + AuthProvider
- `src/store/authStore.js` — access token in memory only, refresh token in `localStorage("cl-refresh")`; `login()`, `logout()`, `setAccessToken()` actions
- `src/api/client.js` — Axios instance; request interceptor attaches Bearer token; 401 response interceptor silently refreshes (one retry per request), logs out on failure
- `src/api/auth.js` — typed wrappers: `loginRequest`, `logoutRequest`, `getMeRequest`, `refreshRequest`
- `src/providers/AuthProvider.jsx` — on cold start: exchanges stored refresh token → fetches `/me/` → hydrates store; shows bolt-icon splash while booting to prevent `/login` flash
- `src/main.jsx` — wraps `AppRouter` in `AuthProvider`
- `src/router/PrivateRoute.jsx` — imports from real `authStore` (not mock)

### Issue #10 — Production LoginPage
- `src/pages/LoginPage.jsx` — full rewrite: split-screen IBM-Carbon-style
  - **Left panel**: dark navy `bg-surface`, CrisisLens wordmark, tagline, stat pills (3 counties / 21 sub-counties / 3.28M people), footer
  - **Right panel**: email + password inputs with inline validation, show/hide password toggle, inline 401/500 error banner, loading spinner on Submit button, Quick Access demo role buttons
  - Correct flow: `POST /api/auth/login/` → store refresh in `localStorage` → `GET /api/auth/me/` → hydrate store → navigate to `from || /dashboard`
- `src/router/DashboardRouter.jsx` — updated import to `authStore`

## Security

- Access token **never** hits `localStorage` or cookies
- Refresh token is stored under key `cl-refresh` and rotated on each use (backend: `ROTATE_REFRESH_TOKENS=True`)
- Silent refresh uses a separate bare `axios` call to prevent interceptor loops

## Test plan

- [x] Cold start with no `cl-refresh` → redirected to `/login`
- [x] Enter `ops@crisislens.go.ke` / `Demo1234!` → redirect to `/dashboard/national`
- [x] DevTools → `localStorage`: `cl-refresh` present; no `cl-access` (memory only)
- [x] Hard refresh → app boots → still logged in (AuthProvider silent rehydrate)
- [x] Wrong password → inline "Invalid email or password" (no page reload)
- [x] Click a Quick Access button → spins → redirected to correct dashboard
- [x] Sign Out → `cl-refresh` cleared → redirect to `/login`
- [x] After logout, replay old refresh token → 401 Token is blacklisted (backend PR #79)

Closes #10 Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)